### PR TITLE
Azure pipelines

### DIFF
--- a/.ci/.gitattributes
+++ b/.ci/.gitattributes
@@ -1,0 +1,6 @@
+# Declare shell files to have LF endings on checkout
+# On Windows, the default git setting for `core.autocrlf`
+# means that when checking out code, LF endings get converted
+# to CRLF. This causes problems for shell scripts, as bash
+# gets choked up on the extra `\r` character.
+*.sh text eol=lf

--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -1,0 +1,19 @@
+# Cross-platform set of build steps for building esy projects
+
+steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '8.9'
+  - script: npm install -g esy@0.5.6
+    displayName: 'npm install -g esy@0.5.6'
+  - script: esy install
+    displayName: 'esy install'
+  - script: esy build
+    displayName: 'esy build'
+  - script: esy b dune runtest
+    displayName: 'esy b dune runtest'
+  - script: esy x Examples
+    displayName: 'esy x Examples'
+    continueOnError: true
+  - script: esy create-release
+    displayName: 'esy create-release'

--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -10,10 +10,3 @@ steps:
     displayName: 'esy install'
   - script: esy build
     displayName: 'esy build'
-  - script: esy b dune runtest
-    displayName: 'esy b dune runtest'
-  - script: esy x Examples
-    displayName: 'esy x Examples'
-    continueOnError: true
-  - script: esy create-release
-    displayName: 'esy create-release'

--- a/.ci/publish-build-cache.yml
+++ b/.ci/publish-build-cache.yml
@@ -1,0 +1,24 @@
+# Steps for publishing project cache
+
+steps:
+  - bash: 'mkdir -p $(STAGING_DIRECTORY_UNIX)'
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    displayName: '[Cache][Publish] Create cache directory'
+
+  - bash: 'cd $(ESY__CACHE_INSTALL_PATH) && tar -czf $(STAGING_DIRECTORY_UNIX)/esy-cache.tar .'
+    workingDirectory: ''
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    displayName: '[Cache][Publish] Tar esy cache directory'
+
+  # - bash: 'cd $(ESY__NPM_ROOT) && tar -czf $(STAGING_DIRECTORY_UNIX)/npm-cache.tar .'
+  #   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  #   displayName: '[Cache][Publish] Tar npm cache directory'
+
+  - task: PublishBuildArtifacts@1
+    displayName: '[Cache][Publish] Upload tarball'
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    inputs:
+        pathToPublish: '$(STAGING_DIRECTORY)'
+        artifactName: 'cache-$(Agent.OS)-install'
+        parallel: true
+        parallelCount: 8

--- a/.ci/publish-release.yml
+++ b/.ci/publish-release.yml
@@ -1,0 +1,10 @@
+# Steps for publishing project cache
+
+steps:
+  - task: PublishBuildArtifacts@1
+    displayName: '[Release]'
+    inputs:
+        pathToPublish: '_release'
+        artifactName: 'release-$(Agent.OS)'
+        parallel: true
+        parallelCount: 8

--- a/.ci/restore-build-cache.yml
+++ b/.ci/restore-build-cache.yml
@@ -1,0 +1,36 @@
+# Steps for restoring project cache
+
+steps:
+  - task: DownloadBuildArtifacts@0
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+    displayName: '[Cache][Restore] Restore install'
+    inputs:
+        buildType: 'specific'
+        project: '$(System.TeamProject)'
+        pipeline: '$(Build.DefinitionName)'
+        branchName: 'refs/heads/master'
+        buildVersionToDownload: 'latestFromBranch'
+        downloadType: 'single'
+        artifactName: 'cache-$(Agent.OS)-install'
+        downloadPath: '$(STAGING_DIRECTORY)'
+    continueOnError: true
+
+  - bash: 'mkdir -p $(ESY__CACHE_INSTALL_PATH)'
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+    displayName: '[Cache][Restore] Create cache directory'
+
+  # - bash: 'cd $(ESY__NPM_ROOT) && tar -xf $(STAGING_DIRECTORY_UNIX)/cache-$(Agent.OS)-install/npm-cache.tar -C .'
+  #   continueOnError: true
+  #   condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+  #   displayName: '[Cache][Restore] Untar npm cache directory'
+
+  - bash: 'cd $(ESY__CACHE_INSTALL_PATH) && tar -xf $(STAGING_DIRECTORY_UNIX)/cache-$(Agent.OS)-install/esy-cache.tar -C .'
+    continueOnError: true
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+    displayName: '[Cache][Restore] Untar esy cache directory'
+
+  - bash: 'rm -rf *'
+    continueOnError: true
+    workingDirectory: '$(STAGING_DIRECTORY)'
+    condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+    displayName: '[Cache][Restore] Clean up'

--- a/.ci/use-node.yml
+++ b/.ci/use-node.yml
@@ -1,0 +1,5 @@
+steps:
+  - task: NodeTool@0
+    displayName: 'Use Node 8.x'
+    inputs:
+      versionSpec: 8.x

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,19 @@
+# Starter pipeline
+# Start with a minimal pipeline that you can customize to build and deploy your code.
+# Add steps that build, run tests, deploy, and more:
+# https://aka.ms/yaml
+
+trigger:
+- master
+
+pool:
+  vmImage: 'Ubuntu-16.04'
+
+steps:
+- script: echo Hello, world!
+  displayName: 'Run a one-line script'
+
+- script: |
+    echo Add other tasks to build, test, and deploy your project.
+    echo See https://aka.ms/yaml
+  displayName: 'Run a multi-line script'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,17 +3,61 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
-trigger:
-- master
+name: $(Build.SourceVersion)
+jobs:
+- job: Linux
+  timeoutInMinutes: 0
+  pool:
+    vmImage: 'Ubuntu 16.04'
 
-pool:
-  vmImage: 'Ubuntu-16.04'
+  variables:
+    STAGING_DIRECTORY: /home/vsts/STAGING
+    STAGING_DIRECTORY_UNIX: /home/vsts/STAGING
+    ESY__CACHE_INSTALL_PATH: /home/vsts/.esy/3_____________________________________________________________________/i
+    ESY__CACHE_SOURCE_TARBALL_PATH: /home/vsts/.esy/source/i
+    # ESY__NPM_ROOT: /opt/hostedtoolcache/node/8.14.0/x64/lib/node_modules/esy
 
-steps:
-- script: echo Hello, world!
-  displayName: 'Run a one-line script'
+  steps:
+  # - script: sudo apt-get install -y libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libegl1-mesa-dev mesa-utils mesa-utils-extra ragel libgtk-3-dev
+  - template: .ci/use-node.yml
+  - template: .ci/restore-build-cache.yml
+  - template: .ci/esy-build-steps.yml
+  - template: .ci/publish-build-cache.yml
 
-- script: |
-    echo Add other tasks to build, test, and deploy your project.
-    echo See https://aka.ms/yaml
-  displayName: 'Run a multi-line script'
+- job: MacOS
+  timeoutInMinutes: 0
+  pool:
+    vmImage: 'macOS 10.13'
+
+  variables:
+    STAGING_DIRECTORY: /Users/vsts/STAGING
+    STAGING_DIRECTORY_UNIX: /Users/vsts/STAGING
+    ESY__CACHE_INSTALL_PATH: /Users/vsts/.esy/3____________________________________________________________________/i
+    ESY__CACHE_SOURCE_TARBALL_PATH: /Users/vsts/.esy/source/i
+    # ESY__NPM_ROOT: /usr/local/lib/node_modules/esy
+
+  steps:
+  # - script: brew update
+  # - script: brew install libpng ragel
+  - template: .ci/use-node.yml
+  - template: .ci/restore-build-cache.yml
+  - template: .ci/esy-build-steps.yml
+  - template: .ci/publish-build-cache.yml
+
+- job: Windows
+  timeoutInMinutes: 0
+  pool:
+    vmImage: 'vs2017-win2016'
+
+  variables:
+    STAGING_DIRECTORY: C:\Users\VssAdministrator\STAGING
+    STAGING_DIRECTORY_UNIX: /C/Users/VssAdministrator/STAGING
+    ESY__CACHE_INSTALL_PATH: /C/Users/VssAdministrator/.esy/3_/i
+    ESY__CACHE_SOURCE_TARBALL_PATH: /C/Users/VssAdministrator/.esy/source/i
+    # ESY__NPM_ROOT: /C/npm/prefix/node_modules/esy
+
+  steps:
+  - template: .ci/use-node.yml
+  - template: .ci/restore-build-cache.yml
+  - template: .ci/esy-build-steps.yml
+  - template: .ci/publish-build-cache.yml

--- a/package.json
+++ b/package.json
@@ -53,8 +53,5 @@
   },
   "dependencies": {
     "@esy-cross/ninja-build": "^1.8.2001"
-  },
-  "devDependencies": {
-      "windows-build-tools": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
   },
   "dependencies": {
     "@esy-cross/ninja-build": "^1.8.2001"
+  },
+  "devDependencies": {
+      "windows-build-tools": "*"
   }
 }


### PR DESCRIPTION
- Add Azure CI pipeline config so we can track the progress of getting `esy-skia` building on all platforms.

Here's a sample run:
https://bryphe.visualstudio.com/esy-skia/_build/results?buildId=1626

### OSX

__Passed!__

### Windows

Failed with:
```
##[command]"C:\windows\system32\cmd.exe" /D /E:ON /V:OFF /S /C "CALL "D:\a\_temp\d986a970-0b86-41c6-9f58-a2065c6ed70b.cmd""
info esy build 0.5.6 (using package.json)
info building @esy-cross/ninja-build@1.8.2001@d41d8cd9
info building @esy-cross/ninja-build@1.8.2001@d41d8cd9: done
esy-build-package: unable to resolve command: python
error: build failed with exit code: 1
  
esy: exiting due to errors above
##[error]Cmd.exe exited with code '1'.
##[section]Finishing: esy build
```

### Linux

Failed with:
```
FAILED: obj/third_party/skcms/skcms.skcms.o 
c++ -MMD -MF obj/third_party/skcms/skcms.skcms.o.d -D_GLIBCXX_DEBUG  -w -std=c11 -fstrict-aliasing -fPIC -g -Werror -Wall -Wextra -Winit-self -Wpointer-arith -Wsign-compare -Wvla -Wno-deprecated-declarations -Wno-maybe-uninitialized -Wno-implicit-fallthrough -Wno-unused-parameter -std=c++14 -fno-exceptions -fno-rtti -Wnon-virtual-dtor -Wno-noexcept-type -c ../../third_party/skcms/skcms.cc -o obj/third_party/skcms/skcms.skcms.o
In file included from ../../third_party/skcms/skcms.cc:1935:0:
../../third_party/skcms/src/Transform_inl.h: In function 'void skx::exec_ops(const Op*, const void**, const char*, char*, int)':
../../third_party/skcms/src/Transform_inl.h:1216:1: error: unrecognizable insn:
 }
 ^
(insn 5716 5715 5717 352 (set (reg:V16SI 2538 [ D.61236 ])
        (lt:HI (reg:V16SF 8443)
            (mem/c:V16SF (plus:DI (reg/f:DI 82 virtual-stack-vars)
                    (const_int -22976 [0xffffffffffffa640])) [5 x+0 S64 A512]))) ../../third_party/skcms/src/Transform_inl.h:202 -1
     (nil))
../../third_party/skcms/src/Transform_inl.h:1216:1: internal compiler error: in extract_insn, at recog.c:2343
Please submit a full bug report,
with preprocessed source if appropriate.
See <file:///usr/share/doc/gcc-5/README.Bugs> for instructions.
[114/3188] compile ../../src/opts/SkOpts_sse41.cpp
[115/3188] compile ../../src/opts/SkOpts_ssse3.cpp
ninja: build stopped: subcommand failed.
error: command failed: 'ninja.exe' '-C' '/home/vsts/work/1/s/_esy/default/store/b/esy_skia-28e3b387/out/Debug' (exited with 1)
esy-build-package: exiting with errors above...
error: build failed with exit code: 1
```